### PR TITLE
Replaces deprecated method call

### DIFF
--- a/src/main/java/com/github/shyykoserhiy/gfm/markdown/offline/MarkdownJna.java
+++ b/src/main/java/com/github/shyykoserhiy/gfm/markdown/offline/MarkdownJna.java
@@ -38,7 +38,7 @@ public interface MarkdownJna extends Library {
                 }
                 return text;
             }
-            return data.getString(0, false);
+            return data.getString(0);
         }
     }
 }


### PR DESCRIPTION
The method `com.sun.jna.Pointer#getString(long, boolean)` was deprecated for some time and is finally removed in recent JNA versions. This change is needed to make the plugin compatible with IDEA 2019.2+ (which will include JNA 5.3.0).